### PR TITLE
13th Age Glorantha: Fix double style attributes in spell slots

### DIFF
--- a/13th Age Glorantha/13th_Age_Glorantha.html
+++ b/13th Age Glorantha/13th_Age_Glorantha.html
@@ -1752,19 +1752,19 @@
                         </span>
                         <span class="sheet-table-h2 sheet-center" style="width:2em;">&sol;</span>
                         <span class="sheet-table-data sheet-center">
-                          <input style="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-1" value="0" title="@{spell-slots-1}" />
+                          <input class="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-1" value="0" title="@{spell-slots-1}" />
                         </span>
                         <span class="sheet-table-data sheet-center">
-                          <input style="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-2" value="0" title="@{spell-slots-2}" />
+                          <input class="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-2" value="0" title="@{spell-slots-2}" />
                         </span>
                         <span class="sheet-table-data sheet-center">
-                          <input style="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-3" value="0" title="@{spell-slots-3}" />
+                          <input class="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-3" value="0" title="@{spell-slots-3}" />
                         </span>
                         <span class="sheet-table-data sheet-center">
-                          <input style="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-4" value="0" title="@{spell-slots-4}" />
+                          <input class="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-4" value="0" title="@{spell-slots-4}" />
                         </span>
                         <span class="sheet-table-data sheet-center">
-                          <input style="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-5" value="0" title="@{spell-slots-5}" />
+                          <input class="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-5" value="0" title="@{spell-slots-5}" />
                         </span>
                         <span class="sheet-table-data sheet-left">
                           <input class="sheet-grow sheet-center sheet-bold" type="number" name="attr_spell-slots-total" value="@{spell-slots-1}+@{spell-slots-2}+@{spell-slots-3}+@{spell-slots-4}+@{spell-slots-5}" title="@{spell-slots-total}" disabled="true" />

--- a/13th Age Glorantha/src/13th_Age_Glorantha.html
+++ b/13th Age Glorantha/src/13th_Age_Glorantha.html
@@ -1752,19 +1752,19 @@
                         </span>
                         <span class="sheet-table-h2 sheet-center" style="width:2em;">&sol;</span>
                         <span class="sheet-table-data sheet-center">
-                          <input style="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-1" value="0" title="@{spell-slots-1}" />
+                          <input class="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-1" value="0" title="@{spell-slots-1}" />
                         </span>
                         <span class="sheet-table-data sheet-center">
-                          <input style="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-2" value="0" title="@{spell-slots-2}" />
+                          <input class="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-2" value="0" title="@{spell-slots-2}" />
                         </span>
                         <span class="sheet-table-data sheet-center">
-                          <input style="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-3" value="0" title="@{spell-slots-3}" />
+                          <input class="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-3" value="0" title="@{spell-slots-3}" />
                         </span>
                         <span class="sheet-table-data sheet-center">
-                          <input style="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-4" value="0" title="@{spell-slots-4}" />
+                          <input class="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-4" value="0" title="@{spell-slots-4}" />
                         </span>
                         <span class="sheet-table-data sheet-center">
-                          <input style="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-5" value="0" title="@{spell-slots-5}" />
+                          <input class="sheet-center" style="width:3em;" type="number" name="attr_spell-slots-5" value="0" title="@{spell-slots-5}" />
                         </span>
                         <span class="sheet-table-data sheet-left">
                           <input class="sheet-grow sheet-center sheet-bold" type="number" name="attr_spell-slots-total" value="@{spell-slots-1}+@{spell-slots-2}+@{spell-slots-3}+@{spell-slots-4}+@{spell-slots-5}" title="@{spell-slots-total}" disabled="true" />


### PR DESCRIPTION
## Changes / Comments

Fix double style attributes in a bunch of input elements, the ones with value `sheet-center` are supposed to be class-attributes.

Mostly this is to make code editors to stop complaining about double attributes. The style changes caused by this are not significant (see row starting with word "Slots):

Before:

![spell-slots-before](https://user-images.githubusercontent.com/186729/110203400-b4d48780-7e76-11eb-9165-997f6df9a57f.png)

After:

![spell-slots-after](https://user-images.githubusercontent.com/186729/110203407-baca6880-7e76-11eb-8c70-2ad2bb1d562c.png)


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
