### PR TITLE
13th Age Glorantha: Do not use html entities in attribute values

### DIFF
--- a/13th Age Glorantha/13th_Age_Glorantha.html
+++ b/13th Age Glorantha/13th_Age_Glorantha.html
@@ -678,7 +678,7 @@
                               </span>
                             </div>
                             <span class="sheet-table-data sheet-left">
-                              <input style="width:230px; position:relative; left:20px;" class="sheet-sans" title="@{repeating_background_X_skill}" name="attr_skill" placeholder="Background &sol; Skill" type="text" />
+                              <input style="width:230px; position:relative; left:20px;" class="sheet-sans" title="@{repeating_background_X_skill}" name="attr_skill" placeholder="Background / Skill" type="text" />
                             </span>
                             <span class="sheet-table-data sheet-left">
                               <input style="width:50px; height:30px;" class="sheet-center sheet-bold sheet-grow" title="@{repeating_background_X_skill-total}" name="attr_skill-total" value="@{skill-mod-selected}+@{level}+@{skill-points}+@{iadv-skill}" type="number" disabled="true" />
@@ -1736,7 +1736,7 @@
                     <div class="sheet-table sheet-sect">
                       <span class="sheet-table-name">
                         <div class="sheet-caps">
-                          <input class="sheet-caps sheet-center" title="@{spells-header}" name="attr_spells-header" type="text" value="&ensp;&nbsp;Spells&ensp;III&ensp;Powers" />
+                          <input class="sheet-caps sheet-center" title="@{spells-header}" name="attr_spells-header" type="text" value="Spells  III  Powers" />
                           <!-- three I's resemble the 'harmony' rune -->
                         </div>
                       </span>
@@ -1847,7 +1847,7 @@
                       <div class="sheet-table sheet-sect">
                         <span class="sheet-table-name">
                           <div class="sheet-caps">
-                            <input style="cursor:text !important;" class="sheet-caps sheet-center" title="@{powers-l-header}" name="attr_powers-l-header" type="text" placeholder="Special &sol; Custom Powers" />
+                            <input style="cursor:text !important;" class="sheet-caps sheet-center" title="@{powers-l-header}" name="attr_powers-l-header" type="text" placeholder="Special / Custom Powers" />
                           </div>
                         </span>
                       </div>
@@ -2001,7 +2001,7 @@
                     <div class="sheet-table sheet-sect">
                       <span class="sheet-table-name">
                         <div class="sheet-caps">
-                          <input class="sheet-caps sheet-center" title="@{gifts-header}" name="attr_gifts-header" type="text" value="&nbsp;Gifts&ensp;III&ensp;Items" />
+                          <input class="sheet-caps sheet-center" title="@{gifts-header}" name="attr_gifts-header" type="text" value="Gifts  III  Items" />
                           <!-- three I's resemble the 'harmony' rune  -->
                         </div>
                       </span>
@@ -2233,7 +2233,7 @@
                         </div>
                       </div>
                       <div class="sheet-table-row">
-                        <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_minion-attack_X_desc}" name="attr_minion-attack-desc" placeholder="Mook attack description &sol; additional effects &sol; use conditions &sol; triggers"></textarea>
+                        <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_minion-attack_X_desc}" name="attr_minion-attack-desc" placeholder="Mook attack description / additional effects / use conditions / triggers"></textarea>
                       </div>
                       <span class="sheet-table-data sheet-left sheet-table-padding sheet-top sheet-sans sheet-normalize">
                         <i><b>Feats</b></i>&nbsp;
@@ -2245,8 +2245,8 @@
                         E&nbsp;
                         &emsp;&emsp;&emsp;
                         <input type="checkbox" class="sheet-law sheet-desc-show" title="@{repeating_minion_X_description-show}" name="attr_description-show" value="1"/>
-                        &emsp;Description &sol; Explanation
-                        <textarea title="@{repeating_minion_X_desc}" class="sheet-desc sheet-textarea-four sheet-serif" style="resize:vertical;" name="attr_description" placeholder = "Description &sol; Explanation"></textarea>
+                        &emsp;Description / Explanation
+                        <textarea title="@{repeating_minion_X_desc}" class="sheet-desc sheet-textarea-four sheet-serif" style="resize:vertical;" name="attr_description" placeholder = "Description / Explanation"></textarea>
                       </span>
                       <hr class="sheet-hr">
                     </fieldset>
@@ -2449,7 +2449,7 @@
                     <div class="sheet-table sheet-sect">
                       <span class="sheet-table-name">
                         <div class="sheet-caps">
-                          <input style="cursor:text !important;" class="sheet-caps sheet-center" title="@{factions-header}" name="attr_factions-header" type="text" placeholder="Factions &sol; Projects" />
+                          <input style="cursor:text !important;" class="sheet-caps sheet-center" title="@{factions-header}" name="attr_factions-header" type="text" placeholder="Factions / Projects" />
                         </div>
                       </span>
                     </div>
@@ -2477,7 +2477,7 @@
                         <div class="sheet-table-row">
                           <div class="sheet-col">
                             <span style="position:relative; left:8px; top:1px;" class="sheet-table-h1 sheet-grow sheet-left">
-                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-1}" name="attr_faction-attribute-1" placeholder="&mdash;">
+                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-1}" name="attr_faction-attribute-1" placeholder="--">
                             </span>
                             <span style="position:relative; left:8px; top:1px;" class="sheet-table-data">
                               <input style="width:8em;" type="text" class="sheet-power-h3 sheet-table-padding sheet-normalize sheet-bold sheet-left sheet-mono" title="@{repeating_faction-value-1}" name="attr_faction-value-1" placeholder="........">
@@ -2485,7 +2485,7 @@
                           </div>
                           <div class="sheet-col">
                             <span class="sheet-table-h1 sheet-grow sheet-left">
-                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-2}" name="attr_faction-attribute-2" placeholder="&mdash;">
+                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-2}" name="attr_faction-attribute-2" placeholder="--">
                             </span>
                             <span class="sheet-table-data">
                               <input style="width:8em;" type="text" class="sheet-power-h3 sheet-table-padding sheet-normalize sheet-bold sheet-left sheet-mono" title="@{repeating_faction-value-2}" name="attr_faction-value-2" placeholder="........">
@@ -2495,7 +2495,7 @@
                         <div class="sheet-table-row sheet-table-underline">
                           <div class="sheet-col">
                             <span style="position:relative; left:8px; top:1px;" class="sheet-table-h1 sheet-grow sheet-left">
-                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-3}" name="attr_faction-attribute-3" placeholder="&mdash;">
+                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-3}" name="attr_faction-attribute-3" placeholder="--">
                             </span>
                             <span style="position:relative; left:8px; top:1px;" class="sheet-table-data">
                               <input style="width:8em;" type="text" class="sheet-power-h3 sheet-table-padding sheet-normalize sheet-bold sheet-left sheet-mono" title="@{repeating_faction-value-3}" name="attr_faction-value-3" placeholder="........">
@@ -2503,7 +2503,7 @@
                           </div>
                           <div class="sheet-col">
                             <span class="sheet-table-h1 sheet-grow sheet-left">
-                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-4}" name="attr_faction-attribute-4" placeholder="&mdash;">
+                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-4}" name="attr_faction-attribute-4" placeholder="--">
                             </span>
                             <span class="sheet-table-data">
                               <input style="width:8em;" type="text" class="sheet-power-h3 sheet-table-padding sheet-normalize sheet-bold sheet-left sheet-mono" title="@{repeating_faction-value-4}" name="attr_faction-value-4" placeholder="........">
@@ -2512,7 +2512,7 @@
                         </div>
                       </div>
                       <div class="sheet-table-row">
-                        <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_faction_X_desc}" name="attr_faction-desc" placeholder="Description &sol; explanation"></textarea>
+                        <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_faction_X_desc}" name="attr_faction-desc" placeholder="Description / explanation"></textarea>
                       </div>
                       <hr class="sheet-hr">
                     </fieldset>
@@ -2792,7 +2792,7 @@
                       </div>
                     </div>
                     <div class="sheet-table-row">
-                      <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_npc-attack_X_desc}" name="attr_npc-attack-desc" placeholder="Attack description &sol; additional effects &sol; use conditions &sol; triggers"></textarea>
+                      <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_npc-attack_X_desc}" name="attr_npc-attack-desc" placeholder="Attack description / additional effects / use conditions / triggers"></textarea>
                     </div>
                   </fieldset>
                   <!-- NPC MOOKS -->
@@ -2916,7 +2916,7 @@
                     </div>
                   </div>
                   <div class="sheet-table-row">
-                    <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_mook-attack_X_desc}" name="attr_mook-attack-desc" placeholder="Mook attack description &sol; additional effects &sol; use conditions &sol; triggers"></textarea>
+                    <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_mook-attack_X_desc}" name="attr_mook-attack-desc" placeholder="Mook attack description / additional effects / use conditions / triggers"></textarea>
                   </div>
                   <hr class="sheet-hr">
                 </fieldset>
@@ -3177,7 +3177,7 @@
                             </span>
                             <span style="width:1%;" class="sheet-table-data sheet-center">&sol;</span>
                             <span style="width:15%;" class="sheet-table-data sheet-center">
-                              <input style="width:3em;" class="sheet-center sheet-dotted" title="@{repeating_meta_X_max}" name="attr_meta-max" placeholder="&mdash;" type="text" />
+                              <input style="width:3em;" class="sheet-center sheet-dotted" title="@{repeating_meta_X_max}" name="attr_meta-max" placeholder="--" type="text" />
                             </span>
                           </div>
                         </div>

--- a/13th Age Glorantha/src/13th_Age_Glorantha.html
+++ b/13th Age Glorantha/src/13th_Age_Glorantha.html
@@ -678,7 +678,7 @@
                               </span>
                             </div>
                             <span class="sheet-table-data sheet-left">
-                              <input style="width:230px; position:relative; left:20px;" class="sheet-sans" title="@{repeating_background_X_skill}" name="attr_skill" placeholder="Background &sol; Skill" type="text" />
+                              <input style="width:230px; position:relative; left:20px;" class="sheet-sans" title="@{repeating_background_X_skill}" name="attr_skill" placeholder="Background / Skill" type="text" />
                             </span>
                             <span class="sheet-table-data sheet-left">
                               <input style="width:50px; height:30px;" class="sheet-center sheet-bold sheet-grow" title="@{repeating_background_X_skill-total}" name="attr_skill-total" value="@{skill-mod-selected}+@{level}+@{skill-points}+@{iadv-skill}" type="number" disabled="true" />
@@ -1736,7 +1736,7 @@
                     <div class="sheet-table sheet-sect">
                       <span class="sheet-table-name">
                         <div class="sheet-caps">
-                          <input class="sheet-caps sheet-center" title="@{spells-header}" name="attr_spells-header" type="text" value="&ensp;&nbsp;Spells&ensp;III&ensp;Powers" />
+                          <input class="sheet-caps sheet-center" title="@{spells-header}" name="attr_spells-header" type="text" value="Spells  III  Powers" />
                           <!-- three I's resemble the 'harmony' rune -->
                         </div>
                       </span>
@@ -1847,7 +1847,7 @@
                       <div class="sheet-table sheet-sect">
                         <span class="sheet-table-name">
                           <div class="sheet-caps">
-                            <input style="cursor:text !important;" class="sheet-caps sheet-center" title="@{powers-l-header}" name="attr_powers-l-header" type="text" placeholder="Special &sol; Custom Powers" />
+                            <input style="cursor:text !important;" class="sheet-caps sheet-center" title="@{powers-l-header}" name="attr_powers-l-header" type="text" placeholder="Special / Custom Powers" />
                           </div>
                         </span>
                       </div>
@@ -2001,7 +2001,7 @@
                     <div class="sheet-table sheet-sect">
                       <span class="sheet-table-name">
                         <div class="sheet-caps">
-                          <input class="sheet-caps sheet-center" title="@{gifts-header}" name="attr_gifts-header" type="text" value="&nbsp;Gifts&ensp;III&ensp;Items" />
+                          <input class="sheet-caps sheet-center" title="@{gifts-header}" name="attr_gifts-header" type="text" value="Gifts  III  Items" />
                           <!-- three I's resemble the 'harmony' rune  -->
                         </div>
                       </span>
@@ -2233,7 +2233,7 @@
                         </div>
                       </div>
                       <div class="sheet-table-row">
-                        <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_minion-attack_X_desc}" name="attr_minion-attack-desc" placeholder="Mook attack description &sol; additional effects &sol; use conditions &sol; triggers"></textarea>
+                        <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_minion-attack_X_desc}" name="attr_minion-attack-desc" placeholder="Mook attack description / additional effects / use conditions / triggers"></textarea>
                       </div>
                       <span class="sheet-table-data sheet-left sheet-table-padding sheet-top sheet-sans sheet-normalize">
                         <i><b>Feats</b></i>&nbsp;
@@ -2245,8 +2245,8 @@
                         E&nbsp;
                         &emsp;&emsp;&emsp;
                         <input type="checkbox" class="sheet-law sheet-desc-show" title="@{repeating_minion_X_description-show}" name="attr_description-show" value="1"/>
-                        &emsp;Description &sol; Explanation
-                        <textarea title="@{repeating_minion_X_desc}" class="sheet-desc sheet-textarea-four sheet-serif" style="resize:vertical;" name="attr_description" placeholder = "Description &sol; Explanation"></textarea>
+                        &emsp;Description / Explanation
+                        <textarea title="@{repeating_minion_X_desc}" class="sheet-desc sheet-textarea-four sheet-serif" style="resize:vertical;" name="attr_description" placeholder = "Description / Explanation"></textarea>
                       </span>
                       <hr class="sheet-hr">
                     </fieldset>
@@ -2449,7 +2449,7 @@
                     <div class="sheet-table sheet-sect">
                       <span class="sheet-table-name">
                         <div class="sheet-caps">
-                          <input style="cursor:text !important;" class="sheet-caps sheet-center" title="@{factions-header}" name="attr_factions-header" type="text" placeholder="Factions &sol; Projects" />
+                          <input style="cursor:text !important;" class="sheet-caps sheet-center" title="@{factions-header}" name="attr_factions-header" type="text" placeholder="Factions / Projects" />
                         </div>
                       </span>
                     </div>
@@ -2477,7 +2477,7 @@
                         <div class="sheet-table-row">
                           <div class="sheet-col">
                             <span style="position:relative; left:8px; top:1px;" class="sheet-table-h1 sheet-grow sheet-left">
-                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-1}" name="attr_faction-attribute-1" placeholder="&mdash;">
+                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-1}" name="attr_faction-attribute-1" placeholder="--">
                             </span>
                             <span style="position:relative; left:8px; top:1px;" class="sheet-table-data">
                               <input style="width:8em;" type="text" class="sheet-power-h3 sheet-table-padding sheet-normalize sheet-bold sheet-left sheet-mono" title="@{repeating_faction-value-1}" name="attr_faction-value-1" placeholder="........">
@@ -2485,7 +2485,7 @@
                           </div>
                           <div class="sheet-col">
                             <span class="sheet-table-h1 sheet-grow sheet-left">
-                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-2}" name="attr_faction-attribute-2" placeholder="&mdash;">
+                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-2}" name="attr_faction-attribute-2" placeholder="--">
                             </span>
                             <span class="sheet-table-data">
                               <input style="width:8em;" type="text" class="sheet-power-h3 sheet-table-padding sheet-normalize sheet-bold sheet-left sheet-mono" title="@{repeating_faction-value-2}" name="attr_faction-value-2" placeholder="........">
@@ -2495,7 +2495,7 @@
                         <div class="sheet-table-row sheet-table-underline">
                           <div class="sheet-col">
                             <span style="position:relative; left:8px; top:1px;" class="sheet-table-h1 sheet-grow sheet-left">
-                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-3}" name="attr_faction-attribute-3" placeholder="&mdash;">
+                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-3}" name="attr_faction-attribute-3" placeholder="--">
                             </span>
                             <span style="position:relative; left:8px; top:1px;" class="sheet-table-data">
                               <input style="width:8em;" type="text" class="sheet-power-h3 sheet-table-padding sheet-normalize sheet-bold sheet-left sheet-mono" title="@{repeating_faction-value-3}" name="attr_faction-value-3" placeholder="........">
@@ -2503,7 +2503,7 @@
                           </div>
                           <div class="sheet-col">
                             <span class="sheet-table-h1 sheet-grow sheet-left">
-                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-4}" name="attr_faction-attribute-4" placeholder="&mdash;">
+                              <input style="width:5em;" type="text" class="sheet-power-h3 sheet-bold sheet-normalize" title="@{repeating_faction-attribute-4}" name="attr_faction-attribute-4" placeholder="--">
                             </span>
                             <span class="sheet-table-data">
                               <input style="width:8em;" type="text" class="sheet-power-h3 sheet-table-padding sheet-normalize sheet-bold sheet-left sheet-mono" title="@{repeating_faction-value-4}" name="attr_faction-value-4" placeholder="........">
@@ -2512,7 +2512,7 @@
                         </div>
                       </div>
                       <div class="sheet-table-row">
-                        <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_faction_X_desc}" name="attr_faction-desc" placeholder="Description &sol; explanation"></textarea>
+                        <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_faction_X_desc}" name="attr_faction-desc" placeholder="Description / explanation"></textarea>
                       </div>
                       <hr class="sheet-hr">
                     </fieldset>
@@ -2792,7 +2792,7 @@
                       </div>
                     </div>
                     <div class="sheet-table-row">
-                      <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_npc-attack_X_desc}" name="attr_npc-attack-desc" placeholder="Attack description &sol; additional effects &sol; use conditions &sol; triggers"></textarea>
+                      <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_npc-attack_X_desc}" name="attr_npc-attack-desc" placeholder="Attack description / additional effects / use conditions / triggers"></textarea>
                     </div>
                   </fieldset>
                   <!-- NPC MOOKS -->
@@ -2916,7 +2916,7 @@
                     </div>
                   </div>
                   <div class="sheet-table-row">
-                    <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_mook-attack_X_desc}" name="attr_mook-attack-desc" placeholder="Mook attack description &sol; additional effects &sol; use conditions &sol; triggers"></textarea>
+                    <textarea style="width:420px;" class="sheet-nostyle sheet-textarea-one" title="@{repeating_mook-attack_X_desc}" name="attr_mook-attack-desc" placeholder="Mook attack description / additional effects / use conditions / triggers"></textarea>
                   </div>
                   <hr class="sheet-hr">
                 </fieldset>
@@ -3177,7 +3177,7 @@
                             </span>
                             <span style="width:1%;" class="sheet-table-data sheet-center">&sol;</span>
                             <span style="width:15%;" class="sheet-table-data sheet-center">
-                              <input style="width:3em;" class="sheet-center sheet-dotted" title="@{repeating_meta_X_max}" name="attr_meta-max" placeholder="&mdash;" type="text" />
+                              <input style="width:3em;" class="sheet-center sheet-dotted" title="@{repeating_meta_X_max}" name="attr_meta-max" placeholder="--" type="text" />
                             </span>
                           </div>
                         </div>


### PR DESCRIPTION
## Changes / Comments

Replace HTML-entities in HTML attribute values (mostly `placeholder` and `value` attributes in `input` elements) with corresponding characters as HTML-entities are not displayed correctly in Roll20 at the moment, like this:

![Screenshot_2021-03-06 Testipeli Roll20](https://user-images.githubusercontent.com/186729/110211121-c8471900-7e9d-11eb-8028-54b16465fe20.png)

Luckily there were no exotic entities used in this sheet, mostly they were dashes, slashes and non-breaking spaces.
## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
