### PR TITLE
13th Age Glorantha: Show level multiplier for weapon die

### DIFF
--- a/13th Age Glorantha/13th_Age_Glorantha.css
+++ b/13th Age Glorantha/13th_Age_Glorantha.css
@@ -163,6 +163,10 @@ input.sheet-caps {
   vertical-align: middle;
 }
 
+div.sheet-2colrow div.sheet-col.sheet-col-narrow {
+  margin-right: 23px;
+}
+
 .sheet-center {
   text-align: center !important;
 }

--- a/13th Age Glorantha/13th_Age_Glorantha.html
+++ b/13th Age Glorantha/13th_Age_Glorantha.html
@@ -703,16 +703,16 @@
                     <div class="sheet-table sheet-sect">
                       <!-- INITIATIVE -->
                       <div class="sheet-table-row sheet-table-underline" style="position:relative; top:3px; height:35px;">
-                        <div class="sheet-col" style="width:4em;">
+                        <div class="sheet-col" style="width:5em;">
                           <div class="sheet-table-h1 sheet-grow sheet-table-padding">
                             <button class="sheet-text-btn sheet-mid" title="Roll initiative" type="roll" value="&{template:13G_white} {{name=Initiative}} {{usage=@{character_name}}} {{type=@{class}}} {{Result=[[[[@{core}]]+[[@{INI-mod}]] &{tracker}]] = $[[0]] + $[[1]]}}" name="roll_INI-check">
                               Initiative
                             </button>
                           </div>
                         </div>
-                        <div class="sheet-col" style="width:2em;">
+                        <div class="sheet-col sheet-col-narrow" style="width:2em;">
                           <div class="sheet-table-data">
-                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:45px;" title="@{INI-mod}" type="number" name="attr_INI-mod" value="@{level}+@{INI-mod-selected}+@{INI-bonus}-@{INI-penalty}" disabled="true">
+                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:40px;" title="@{INI-mod}" type="number" name="attr_INI-mod" value="@{level}+@{INI-mod-selected}+@{INI-bonus}-@{INI-penalty}" disabled="true">
                           </div>
                         </div>
                         <div class="sheet-col" style="width:3em;">
@@ -766,16 +766,16 @@
                       </div>
                       <!-- primary MELEE -->
                       <div class="sheet-table-row" style="position:relative; top:3px; height:35px;">
-                        <div class="sheet-col" style="width:4em;">
+                        <div class="sheet-col" style="width:5em;">
                           <div class="sheet-table-h1 sheet-big sheet-table-padding">
                             <button title="Primary melee attack roll" class="sheet-text-btn sheet-mid" type="roll" type="roll" title="%{PMA-check}" value="&{template:13G_red} {{name=@{pma-wpn}}} {{usage=@{MA-vs}}} {{type=Basic Attack}} {{Result=@{pma}}} {{Hit=@{pmd}}} {{Miss=[[@{MAD-miss}]]}}" name="roll_PMA-check">
                               Melee
                             </button>
                           </div>
                         </div>
-                        <div class="sheet-col" style="width:2em;">
+                        <div class="sheet-col sheet-col-narrow" style="width:2em;">
                           <div class="sheet-table-data">
-                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:45px;" title="@{MA-mod}" type="number" name="attr_MA-mod" value="@{level}+@{MA-mod-selected}+@{MA-bonus}-(@{MA-penalty}+@{penalty-dazed}+@{penalty-weakened})" disabled="true">
+                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:40px;" title="@{MA-mod}" type="number" name="attr_MA-mod" value="@{level}+@{MA-mod-selected}+@{MA-bonus}-(@{MA-penalty}+@{penalty-dazed}+@{penalty-weakened})" disabled="true">
                           </div>
                         </div>
                         <div class="sheet-col" style="width:3em;">
@@ -828,20 +828,23 @@
                         </div>
                       </div>
                       <div class="sheet-table-row sheet-table-dotted" style="position:relative; height:30px;">
-                        <div class="sheet-col" style="width:4em;">
+                        <div class="sheet-col" style="width:5em;">
                           <div class="sheet-table-data">
+                            <span style="position:relative;padding-left:10px;" class="sheet-table-data sheet-sans sheet-bold sheet-big sheet-center sheet-left" title="Level">
+                              <span name="attr_level"></span>&times;
+                            </span>
                             <span style="position:relative;" class="sheet-table-data sheet-right">
-                              <input style="width:2em;" class="sheet-right sheet-grow" title="@{MAD-die-count}" type="number" name="attr_MAD-die-count" value="1">
+                              <input style="width:1em;" class="sheet-right sheet-grow sheet-bold" title="@{MAD-die-count}" type="number" name="attr_MAD-die-count" value="1">
                             </span>
                             <span style="position:relative;" class="sheet-table-data sheet-sans sheet-bold sheet-big sheet-center sheet-mid">D</span>
                             <span style="position:relative;" class="sheet-table-data sheet-left">
-                              <input style="width:2em;" class="sheet-left sheet-grow sheet-bold" title="@{MAD-die}" type="number" name="attr_MAD-die" value="2">
+                              <input style="width:1.5em;" class="sheet-left sheet-grow sheet-bold" title="@{MAD-die}" type="number" name="attr_MAD-die" value="2">
                             </span>
                           </div>
                         </div>
-                        <div class="sheet-col" style="width:2em;">
+                        <div class="sheet-col sheet-col-narrow" style="width:2em;">
                           <div class="sheet-table-data">
-                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:45px;" title="@{MAD-mod}" type="number" name="attr_MAD-mod" value="@{MAD-mod-selected}*@{tm}+@{MAD-bonus}-@{MAD-penalty}" disabled="true">
+                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:40px;" title="@{MAD-mod}" type="number" name="attr_MAD-mod" value="@{MAD-mod-selected}*@{tm}+@{MAD-bonus}-@{MAD-penalty}" disabled="true">
                           </div>
                         </div>
                         <div class="sheet-col" style="width:3em;">
@@ -895,16 +898,16 @@
                       </div>
                       <!-- primary RANGED -->
                       <div class="sheet-table-row" style="position:relative; top:3px; height:35px;">
-                        <div class="sheet-col" style="width:4em;">
+                        <div class="sheet-col" style="width:5em;">
                           <div class="sheet-table-h1 sheet-big sheet-table-padding">
-                            <button title="Primary ranged attack roll" class="sheet-text-btn sheet-mid" type="roll" type="roll" title="%{PRA-check}" value="&{template:13G_red} {{name=@{pra-wpn}}} {{usage=@{RA-vs}}} {{type=Basic Attack}} {{Result=@{pra}}} {{Hit=@{pmd}}} {{Miss=[[@{RAD-miss}]]}}" name="roll_PRA-check">
+                            <button title="Primary ranged attack roll" class="sheet-text-btn sheet-mid" type="roll" type="roll" title="%{PRA-check}" value="&{template:13G_red} {{name=@{pra-wpn}}} {{usage=@{RA-vs}}} {{type=Basic Attack}} {{Result=@{pra}}} {{Hit=@{prd}}} {{Miss=[[@{RAD-miss}]]}}" name="roll_PRA-check">
                               Ranged
                             </button>
                           </div>
                         </div>
-                        <div class="sheet-col" style="width:2em;">
+                        <div class="sheet-col sheet-col-narrow" style="width:2em;">
                           <div class="sheet-table-data">
-                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:45px;" title="@{RA-mod}" type="number" name="attr_RA-mod" value="@{level}+@{RA-mod-selected}+@{RA-bonus}-(@{RA-penalty}+@{penalty-dazed}+@{penalty-weakened})" disabled="true">
+                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:40px;" title="@{RA-mod}" type="number" name="attr_RA-mod" value="@{level}+@{RA-mod-selected}+@{RA-bonus}-(@{RA-penalty}+@{penalty-dazed}+@{penalty-weakened})" disabled="true">
                           </div>
                         </div>
                         <div class="sheet-col" style="width:3em;">
@@ -957,20 +960,23 @@
                         </div>
                       </div>
                       <div class="sheet-table-row sheet-table-underline" style="position:relative; height:30px;">
-                        <div class="sheet-col" style="width:4em;">
+                        <div class="sheet-col" style="width:5em;">
                           <div class="sheet-table-data">
+                            <span style="position:relative;padding-left:10px;" class="sheet-table-data sheet-sans sheet-bold sheet-big sheet-center sheet-left" title="Level">
+                              <span name="attr_level"></span>&times;
+                            </span>
                             <span style="position:relative;" class="sheet-table-data sheet-right">
-                              <input style="width:2em;" class="sheet-right sheet-grow" title="@{RAD-die-count}" type="number" name="attr_RAD-die-count" value="1">
+                              <input style="width:1em;" class="sheet-right sheet-grow sheet-bold" title="@{RAD-die-count}" type="number" name="attr_RAD-die-count" value="1">
                             </span>
                             <span style="position:relative;" class="sheet-table-data sheet-sans sheet-bold sheet-big sheet-center sheet-mid">D</span>
                             <span style="position:relative;" class="sheet-table-data sheet-left">
-                              <input style="width:2em;" class="sheet-left sheet-grow sheet-bold" title="@{RAD-die}" type="number" name="attr_RAD-die" value="4">
+                              <input style="width:1.5em;" class="sheet-left sheet-grow sheet-bold" title="@{RAD-die}" type="number" name="attr_RAD-die" value="4">
                             </span>
                           </div>
                         </div>
-                        <div class="sheet-col" style="width:2em;">
+                        <div class="sheet-col sheet-col-narrow" style="width:2em;">
                           <div class="sheet-table-data">
-                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:45px;" title="@{RAD-mod}" type="number" name="attr_RAD-mod" value="@{RAD-mod-selected}*@{tm}+@{RAD-bonus}-@{RAD-penalty}" disabled="true">
+                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:40px;" title="@{RAD-mod}" type="number" name="attr_RAD-mod" value="@{RAD-mod-selected}*@{tm}+@{RAD-bonus}-@{RAD-penalty}" disabled="true">
                           </div>
                         </div>
                         <div class="sheet-col" style="width:3em;">
@@ -1023,10 +1029,10 @@
                         </div>
                       </div>
                       <div class="sheet-table-row" style="position:relative; top:3px; height:33px;">
-                        <div class="sheet-col" style="width:4em;">
+                        <div class="sheet-col" style="width:5em;">
                           <div class="sheet-table-data sheet-center sheet-emph sheet-bold" style="position:relative; left:32px;">Dice</div>
                         </div>
-                        <div class="sheet-col" style="width:2em;">
+                        <div class="sheet-col sheet-col-narrow" style="width:2em;">
                           <div class="sheet-table-data sheet-center sheet-emph sheet-bold" style="position:relative; left:8px;">Total</div>
                         </div>
                         <div class="sheet-col" style="width:3em; position:relative; left:8px;">

--- a/13th Age Glorantha/src/13th_Age_Glorantha.css
+++ b/13th Age Glorantha/src/13th_Age_Glorantha.css
@@ -163,6 +163,10 @@ input.sheet-caps {
   vertical-align: middle;
 }
 
+div.sheet-2colrow div.sheet-col.sheet-col-narrow {
+  margin-right: 23px;
+}
+
 .sheet-center {
   text-align: center !important;
 }

--- a/13th Age Glorantha/src/13th_Age_Glorantha.html
+++ b/13th Age Glorantha/src/13th_Age_Glorantha.html
@@ -703,16 +703,16 @@
                     <div class="sheet-table sheet-sect">
                       <!-- INITIATIVE -->
                       <div class="sheet-table-row sheet-table-underline" style="position:relative; top:3px; height:35px;">
-                        <div class="sheet-col" style="width:4em;">
+                        <div class="sheet-col" style="width:5em;">
                           <div class="sheet-table-h1 sheet-grow sheet-table-padding">
                             <button class="sheet-text-btn sheet-mid" title="Roll initiative" type="roll" value="&{template:13G_white} {{name=Initiative}} {{usage=@{character_name}}} {{type=@{class}}} {{Result=[[[[@{core}]]+[[@{INI-mod}]] &{tracker}]] = $[[0]] + $[[1]]}}" name="roll_INI-check">
                               Initiative
                             </button>
                           </div>
                         </div>
-                        <div class="sheet-col" style="width:2em;">
+                        <div class="sheet-col sheet-col-narrow" style="width:2em;">
                           <div class="sheet-table-data">
-                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:45px;" title="@{INI-mod}" type="number" name="attr_INI-mod" value="@{level}+@{INI-mod-selected}+@{INI-bonus}-@{INI-penalty}" disabled="true">
+                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:40px;" title="@{INI-mod}" type="number" name="attr_INI-mod" value="@{level}+@{INI-mod-selected}+@{INI-bonus}-@{INI-penalty}" disabled="true">
                           </div>
                         </div>
                         <div class="sheet-col" style="width:3em;">
@@ -766,16 +766,16 @@
                       </div>
                       <!-- primary MELEE -->
                       <div class="sheet-table-row" style="position:relative; top:3px; height:35px;">
-                        <div class="sheet-col" style="width:4em;">
+                        <div class="sheet-col" style="width:5em;">
                           <div class="sheet-table-h1 sheet-big sheet-table-padding">
                             <button title="Primary melee attack roll" class="sheet-text-btn sheet-mid" type="roll" type="roll" title="%{PMA-check}" value="&{template:13G_red} {{name=@{pma-wpn}}} {{usage=@{MA-vs}}} {{type=Basic Attack}} {{Result=@{pma}}} {{Hit=@{pmd}}} {{Miss=[[@{MAD-miss}]]}}" name="roll_PMA-check">
                               Melee
                             </button>
                           </div>
                         </div>
-                        <div class="sheet-col" style="width:2em;">
+                        <div class="sheet-col sheet-col-narrow" style="width:2em;">
                           <div class="sheet-table-data">
-                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:45px;" title="@{MA-mod}" type="number" name="attr_MA-mod" value="@{level}+@{MA-mod-selected}+@{MA-bonus}-(@{MA-penalty}+@{penalty-dazed}+@{penalty-weakened})" disabled="true">
+                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:40px;" title="@{MA-mod}" type="number" name="attr_MA-mod" value="@{level}+@{MA-mod-selected}+@{MA-bonus}-(@{MA-penalty}+@{penalty-dazed}+@{penalty-weakened})" disabled="true">
                           </div>
                         </div>
                         <div class="sheet-col" style="width:3em;">
@@ -828,20 +828,23 @@
                         </div>
                       </div>
                       <div class="sheet-table-row sheet-table-dotted" style="position:relative; height:30px;">
-                        <div class="sheet-col" style="width:4em;">
+                        <div class="sheet-col" style="width:5em;">
                           <div class="sheet-table-data">
+                            <span style="position:relative;padding-left:10px;" class="sheet-table-data sheet-sans sheet-bold sheet-big sheet-center sheet-left" title="Level">
+                              <span name="attr_level"></span>&times;
+                            </span>
                             <span style="position:relative;" class="sheet-table-data sheet-right">
-                              <input style="width:2em;" class="sheet-right sheet-grow" title="@{MAD-die-count}" type="number" name="attr_MAD-die-count" value="1">
+                              <input style="width:1em;" class="sheet-right sheet-grow sheet-bold" title="@{MAD-die-count}" type="number" name="attr_MAD-die-count" value="1">
                             </span>
                             <span style="position:relative;" class="sheet-table-data sheet-sans sheet-bold sheet-big sheet-center sheet-mid">D</span>
                             <span style="position:relative;" class="sheet-table-data sheet-left">
-                              <input style="width:2em;" class="sheet-left sheet-grow sheet-bold" title="@{MAD-die}" type="number" name="attr_MAD-die" value="2">
+                              <input style="width:1.5em;" class="sheet-left sheet-grow sheet-bold" title="@{MAD-die}" type="number" name="attr_MAD-die" value="2">
                             </span>
                           </div>
                         </div>
-                        <div class="sheet-col" style="width:2em;">
+                        <div class="sheet-col sheet-col-narrow" style="width:2em;">
                           <div class="sheet-table-data">
-                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:45px;" title="@{MAD-mod}" type="number" name="attr_MAD-mod" value="@{MAD-mod-selected}*@{tm}+@{MAD-bonus}-@{MAD-penalty}" disabled="true">
+                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:40px;" title="@{MAD-mod}" type="number" name="attr_MAD-mod" value="@{MAD-mod-selected}*@{tm}+@{MAD-bonus}-@{MAD-penalty}" disabled="true">
                           </div>
                         </div>
                         <div class="sheet-col" style="width:3em;">
@@ -895,16 +898,16 @@
                       </div>
                       <!-- primary RANGED -->
                       <div class="sheet-table-row" style="position:relative; top:3px; height:35px;">
-                        <div class="sheet-col" style="width:4em;">
+                        <div class="sheet-col" style="width:5em;">
                           <div class="sheet-table-h1 sheet-big sheet-table-padding">
-                            <button title="Primary ranged attack roll" class="sheet-text-btn sheet-mid" type="roll" type="roll" title="%{PRA-check}" value="&{template:13G_red} {{name=@{pra-wpn}}} {{usage=@{RA-vs}}} {{type=Basic Attack}} {{Result=@{pra}}} {{Hit=@{pmd}}} {{Miss=[[@{RAD-miss}]]}}" name="roll_PRA-check">
+                            <button title="Primary ranged attack roll" class="sheet-text-btn sheet-mid" type="roll" type="roll" title="%{PRA-check}" value="&{template:13G_red} {{name=@{pra-wpn}}} {{usage=@{RA-vs}}} {{type=Basic Attack}} {{Result=@{pra}}} {{Hit=@{prd}}} {{Miss=[[@{RAD-miss}]]}}" name="roll_PRA-check">
                               Ranged
                             </button>
                           </div>
                         </div>
-                        <div class="sheet-col" style="width:2em;">
+                        <div class="sheet-col sheet-col-narrow" style="width:2em;">
                           <div class="sheet-table-data">
-                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:45px;" title="@{RA-mod}" type="number" name="attr_RA-mod" value="@{level}+@{RA-mod-selected}+@{RA-bonus}-(@{RA-penalty}+@{penalty-dazed}+@{penalty-weakened})" disabled="true">
+                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:40px;" title="@{RA-mod}" type="number" name="attr_RA-mod" value="@{level}+@{RA-mod-selected}+@{RA-bonus}-(@{RA-penalty}+@{penalty-dazed}+@{penalty-weakened})" disabled="true">
                           </div>
                         </div>
                         <div class="sheet-col" style="width:3em;">
@@ -957,20 +960,23 @@
                         </div>
                       </div>
                       <div class="sheet-table-row sheet-table-underline" style="position:relative; height:30px;">
-                        <div class="sheet-col" style="width:4em;">
+                        <div class="sheet-col" style="width:5em;">
                           <div class="sheet-table-data">
+                            <span style="position:relative;padding-left:10px;" class="sheet-table-data sheet-sans sheet-bold sheet-big sheet-center sheet-left" title="Level">
+                              <span name="attr_level"></span>&times;
+                            </span>
                             <span style="position:relative;" class="sheet-table-data sheet-right">
-                              <input style="width:2em;" class="sheet-right sheet-grow" title="@{RAD-die-count}" type="number" name="attr_RAD-die-count" value="1">
+                              <input style="width:1em;" class="sheet-right sheet-grow sheet-bold" title="@{RAD-die-count}" type="number" name="attr_RAD-die-count" value="1">
                             </span>
                             <span style="position:relative;" class="sheet-table-data sheet-sans sheet-bold sheet-big sheet-center sheet-mid">D</span>
                             <span style="position:relative;" class="sheet-table-data sheet-left">
-                              <input style="width:2em;" class="sheet-left sheet-grow sheet-bold" title="@{RAD-die}" type="number" name="attr_RAD-die" value="4">
+                              <input style="width:1.5em;" class="sheet-left sheet-grow sheet-bold" title="@{RAD-die}" type="number" name="attr_RAD-die" value="4">
                             </span>
                           </div>
                         </div>
-                        <div class="sheet-col" style="width:2em;">
+                        <div class="sheet-col sheet-col-narrow" style="width:2em;">
                           <div class="sheet-table-data">
-                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:45px;" title="@{RAD-mod}" type="number" name="attr_RAD-mod" value="@{RAD-mod-selected}*@{tm}+@{RAD-bonus}-@{RAD-penalty}" disabled="true">
+                            <input class="sheet-center sheet-bold sheet-grow" style="height:28px; width:40px;" title="@{RAD-mod}" type="number" name="attr_RAD-mod" value="@{RAD-mod-selected}*@{tm}+@{RAD-bonus}-@{RAD-penalty}" disabled="true">
                           </div>
                         </div>
                         <div class="sheet-col" style="width:3em;">
@@ -1023,10 +1029,10 @@
                         </div>
                       </div>
                       <div class="sheet-table-row" style="position:relative; top:3px; height:33px;">
-                        <div class="sheet-col" style="width:4em;">
+                        <div class="sheet-col" style="width:5em;">
                           <div class="sheet-table-data sheet-center sheet-emph sheet-bold" style="position:relative; left:32px;">Dice</div>
                         </div>
-                        <div class="sheet-col" style="width:2em;">
+                        <div class="sheet-col sheet-col-narrow" style="width:2em;">
                           <div class="sheet-table-data sheet-center sheet-emph sheet-bold" style="position:relative; left:8px;">Total</div>
                         </div>
                         <div class="sheet-col" style="width:3em; position:relative; left:8px;">


### PR DESCRIPTION
## Changes / Comments

 I'm not sure how you feel about this one, but I felt that not displaying the level multiplier for weapon die could quite confusing for players who do not know the rules by heart, so in this suggestion I added `@level x` in front of the weapon die to make it clearer how many dice is actually rolled.

Before:

![Screenshot_2021-03-07 13th Age Glorantha official test Roll20](https://user-images.githubusercontent.com/186729/110238836-6ee9f300-7f4c-11eb-9ae2-532c1c84d0c3.png)

After:

![Screenshot_2021-03-07 13th Age Glorantha -testi Roll20(1)](https://user-images.githubusercontent.com/186729/110239201-790cf100-7f4e-11eb-978d-00b49f9f6336.png)

I made the "Total" column a bit narrower to make all numbers and fields fit nicely, but I think still doesn't look too crowded.

Also I fixed a bug that caused ranged attack to use melee damage.

## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [x] Does the pull request title have the sheet name(s)? Include each sheet name.
- [x] Is this a bug fix?
- [x] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
