### PR TITLE
[13th Age Glorantha] Fix disabling number input field controls on Chrome

### DIFF
--- a/13th Age Glorantha/13th_Age_Glorantha.css
+++ b/13th Age Glorantha/13th_Age_Glorantha.css
@@ -296,8 +296,8 @@ input[type="text"], input[type="number"] {
   border-style: none;
 }
 
-input[type=number]:-webkit-outer-spin-button,
-input[type=number]:-webkit-inner-spin-button {
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }

--- a/13th Age Glorantha/src/13th_Age_Glorantha.css
+++ b/13th Age Glorantha/src/13th_Age_Glorantha.css
@@ -296,8 +296,8 @@ input[type="text"], input[type="number"] {
   border-style: none;
 }
 
-input[type=number]:-webkit-outer-spin-button,
-input[type=number]:-webkit-inner-spin-button {
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }


### PR DESCRIPTION
## Changes / Comments

The selectors used here are pseudo-elements, not pseudo-classes, so we need to use a double colon:

https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-outer-spin-button

Before:

![app roll20 net_editor_](https://user-images.githubusercontent.com/186729/111802857-2250d100-88d7-11eb-8414-bb3afe83409a.png)

After:

![app roll20 net_editor_ (1)](https://user-images.githubusercontent.com/186729/111802883-28df4880-88d7-11eb-87de-428ff4b19fbe.png)

I also added the quotes for consistency, as they are used in other similar selectors.


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
