### PR TITLE
[13th Age Glorantha] Center dropdown text on Chrome

### DIFF
--- a/13th Age Glorantha/13th_Age_Glorantha.css
+++ b/13th Age Glorantha/13th_Age_Glorantha.css
@@ -366,6 +366,7 @@ select {
   appearance: none;
   background-color: transparent;
   text-align: center;
+  text-align-last: center;
   border-style: solid;
   border-color: darkgray;
   border-width: 0px 0px 2px 0px;

--- a/13th Age Glorantha/src/13th_Age_Glorantha.css
+++ b/13th Age Glorantha/src/13th_Age_Glorantha.css
@@ -366,6 +366,7 @@ select {
   appearance: none;
   background-color: transparent;
   text-align: center;
+  text-align-last: center;
   border-style: solid;
   border-color: darkgray;
   border-width: 0px 0px 2px 0px;


### PR DESCRIPTION
## Changes / Comments

Select-elements chosen value was not centered on Chrome, looks a bit nicer now.

Before:

![app roll20 net_editor_ (1)](https://user-images.githubusercontent.com/186729/111804248-917af500-88d8-11eb-9f4f-fa1ba8ed337e.png)

After:

![app roll20 net_editor_ (2)](https://user-images.githubusercontent.com/186729/111804267-96d83f80-88d8-11eb-839f-e59a5967215c.png)


## Roll20 Requests

Comments are very helpful for reviewing the code changes. Please answer the relevant questions below in your comment.

- [X] Does the pull request title have the sheet name(s)? Include each sheet name.
- [X] Is this a bug fix?
- [ ] Does this add functional enhancements (new features or extending existing features) ?
- [ ] Does this add or change functional aesthetics (such as layout or color scheme) ? 
- [ ] If changing or removing attributes, what steps have you taken, if any, to preserve player data ?
- [ ] If this is a new sheet, did you follow [Building Character Sheets standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) ?

If you do not know English. Please leave a comment in your native language.
